### PR TITLE
spawn: add missing _GPGRT_NEED_AFLOCAL define in spawn-posix.c

### DIFF
--- a/src/spawn-posix.c
+++ b/src/spawn-posix.c
@@ -55,6 +55,7 @@
 # include <dirent.h>
 #endif /*__linux__ */
 
+#define _GPGRT_NEED_AFLOCAL 1
 #include "gpgrt-int.h"
 
 


### PR DESCRIPTION
Required for building under Solaris to get fallback AF_LOCAL (AF_UNIX) define setup.